### PR TITLE
Add ability of multiple inputs or outputs to each operator.

### DIFF
--- a/jquery.flowchart.js
+++ b/jquery.flowchart.js
@@ -210,16 +210,17 @@ $(function() {
             if (!multipleLinksOnOutput || !multipleLinksOnInput) {
                 for (var linkId2 in this.data.links) {
                     var currentLink = this.data.links[linkId2];
+                    var currentOperator = this.data.operators[currentLink.fromOperator];
                   
                     var currentSubConnectors = this._getSubConnectors(currentLink);
                     var currentFromSubConnector = currentSubConnectors[0];
                     var currentToSubConnector = currentSubConnectors[1];
                     
-                    if (!multipleLinksOnOutput && currentLink.fromOperator == linkData.fromOperator && currentLink.fromConnector == linkData.fromConnector && currentFromSubConnector == fromSubConnector) {
+                    if (!multipleLinksOnOutput && !currentOperator.properties.multipleLinksOnOutput && currentLink.fromOperator == linkData.fromOperator && currentLink.fromConnector == linkData.fromConnector && currentFromSubConnector == fromSubConnector) {
                         this.deleteLink(linkId2);
                         continue;
                     }
-                    if (!multipleLinksOnInput && currentLink.toOperator == linkData.toOperator && currentLink.toConnector == linkData.toConnector && currentToSubConnector == toSubConnector) {
+                    if (!multipleLinksOnInput && !currentOperator.properties.multipleLinksOnInput && currentLink.toOperator == linkData.toOperator && currentLink.toConnector == linkData.toConnector && currentToSubConnector == toSubConnector) {
                         this.deleteLink(linkId2);
                         continue;
                     }


### PR DESCRIPTION
Now if user define `multipleLinksOnOutput` or `multipleLinksOnInput` on operator, the desired operator can have multiple output or input. For example, if we define `multipleLinksOnOutput` on `Example 2` of http://sebastien.drouyer.com/jquery.flowchart-demo

```js
operator1: {
    top: 20,
    left: 20,
    properties: {
        title: 'Operator 1',
        multipleLinksOnOutput: true, // Add ability of multiple output to this operator.
        inputs: {},
        outputs: {
            output_1: {
                label: 'Output 1',
            }
        }
    }
},
```
`Operator 1` can have multiple outputs, but others are as usual.
