### PR TITLE
Make grid optional & Add free option to operator

### DIFF
--- a/jquery.flowchart.js
+++ b/jquery.flowchart.js
@@ -567,8 +567,10 @@ $(function () {
 
             var grid = this.options.grid;
 
-            operatorData.top = Math.round(operatorData.top / grid) * grid;
-            operatorData.left = Math.round(operatorData.left / grid) * grid;
+            if (grid) {
+                operatorData.top = Math.round(operatorData.top / grid) * grid;
+                operatorData.left = Math.round(operatorData.left / grid) * grid;
+            }
 
             fullElement.operator.appendTo(this.objs.layers.operators);
             fullElement.operator.css({top: operatorData.top, left: operatorData.left});
@@ -614,13 +616,15 @@ $(function () {
                         pointerY = (e.pageY - elementOffset.top) / self.positionRatio - parseInt($(e.target).css('top'));
                     },
                     drag: function (e, ui) {
-                        var grid = self.options.grid;
-                        var elementOffset = self.element.offset();
-                        ui.position.left = Math.round(((e.pageX - elementOffset.left) / self.positionRatio - pointerX) / grid) * grid;
-                        ui.position.top = Math.round(((e.pageY - elementOffset.top) / self.positionRatio - pointerY) / grid) * grid;
-                        ui.offset.left = Math.round(ui.position.left + elementOffset.left);
-                        ui.offset.top = Math.round(ui.position.top + elementOffset.top);
-                        fullElement.operator.css({left: ui.position.left, top: ui.position.top});
+                        if (grid) {
+                            var grid = self.options.grid;
+                            var elementOffset = self.element.offset();
+                            ui.position.left = Math.round(((e.pageX - elementOffset.left) / self.positionRatio - pointerX) / grid) * grid;
+                            ui.position.top = Math.round(((e.pageY - elementOffset.top) / self.positionRatio - pointerY) / grid) * grid;
+                            ui.offset.left = Math.round(ui.position.left + elementOffset.left);
+                            ui.offset.top = Math.round(ui.position.top + elementOffset.top);
+                            fullElement.operator.css({left: ui.position.left, top: ui.position.top});
+                        }
                         operatorChangedPosition($(this).data('operator_id'), ui.position);
                     },
                     stop: function (e, ui) {

--- a/jquery.flowchart.js
+++ b/jquery.flowchart.js
@@ -605,6 +605,7 @@ $(function () {
                 var pointerX;
                 var pointerY;
                 fullElement.operator.draggable({
+                    containment: operatorData.free ? false : this.element,
                     handle: '.flowchart-operator-title',
                     start: function (e, ui) {
                         if (self.lastOutputConnectorClicked != null) {


### PR DESCRIPTION
### Make grid optional
If you set grid option to 0, it'll be disabled.
```
$("#designer").flowchart({
    data: data,
    grid: 0 // Disabled, movement will not be effected by grid positioning
});
```

---
### Add free option to operator
If you set `free` to `true` operator will move freely (possible to move out from flowchart element, also from `document` and `window` too, see issue #18).
If you set `free` to `false` operator will be [contained](http://api.jqueryui.com/draggable/#option-containment) in flowchart element itself (that means will not go out).
```
var data = {
    operators: {
        operator1: {
            top: 100,
            left: 100,
            properties: {
                title: "Operator 1",
                inputs: {
                    input1: {
                        label: "Input 1"
                    }
                }
            },
            free: true // Allowed, can be moved out from element, document and body (completely free!)
        }
    }
};
```