### PR TITLE
listen pointerdown event

### DIFF
--- a/jquery.flowchart.js
+++ b/jquery.flowchart.js
@@ -131,7 +131,7 @@ $(function () {
             });
 
 
-            this.objs.layers.operators.on('mousedown touchstart', '.flowchart-operator', function (e) {
+            this.objs.layers.operators.on('pointerdown mousedown touchstart', '.flowchart-operator', function (e) {
                 e.stopImmediatePropagation();
             });
 


### PR DESCRIPTION
To work with PANZOOM plugin. (See the advanced demo, for panzoom demo, can not move operator on Chrome since panzoom handle pointerdown event but flowchart not.)