### PR TITLE
Fix for Issue #55

### DIFF
--- a/jquery.flowchart.js
+++ b/jquery.flowchart.js
@@ -253,7 +253,7 @@ $(function () {
         },
 
         _autoCreateSubConnector: function (operator, connector, connectorType, subConnector) {
-            var connectorInfos = this.data.operators[operator].properties[connectorType][connector];
+            var connectorInfos = this.data.operators[operator].internal.properties[connectorType][connector];
             if (connectorInfos.multiple) {
                 var fromFullElement = this.data.operators[operator].internal.els;
                 var nbFromConnectors = this.data.operators[operator].internal.els.connectors[connector].length;


### PR DESCRIPTION
It is a one word fix that makes connectors work properly when using operatorTypes - does not stop explicitly defined operators and connectors from working